### PR TITLE
feat(link-curator): v1.1.0 - optional TITLE column + forbidden-char validation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/orientpine"
   },
   "metadata": {
-    "version": "3.28.1",
+    "version": "3.29.0",
     "description": "ISD 연구계획서 생성, 시각자료 프롬프트, DC연금 포트폴리오 분석을 위한 Claude Code 플러그인 마켓플레이스"
   },
   "plugins": [
@@ -231,7 +231,7 @@
       "name": "link-curator",
       "source": "./plugins/link-curator",
       "description": "URL → Korean markdown summary notes (link-summarizer) + HoneyCombo submission (honeycombo-submit). URL fetch/classify, structured Korean md generation, single/bulk GitHub Issue submission.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "strict": true,
       "skills": ["./skills"],
       "license": "MIT",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # TOOLBOX PROJECT KNOWLEDGE BASE
 
 **Generated:** 2026-04-21
-**Version:** 3.28.1
+**Version:** 3.29.0
 **Branch:** main
 
 ## OVERVIEW

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Claude Code 플러그인 마켓플레이스 — AI 에이전트 기반 문서 생성, 시각자료, 투자 분석, 특허 분석, 개발 도구
 
-**Version**: 3.28.1 &nbsp;|&nbsp; **Author**: [Baekdong Cha](https://github.com/orientpine) &nbsp;|&nbsp; **License**: MIT
+**Version**: 3.29.0 &nbsp;|&nbsp; **Author**: [Baekdong Cha](https://github.com/orientpine) &nbsp;|&nbsp; **License**: MIT
 
 ---
 
@@ -1177,6 +1177,7 @@ honeypot/
 
 | 버전 | 날짜 | 변경 내용 |
 |:----:|:----:|----------|
+| 3.29.0 | 2026-04-21 | link-curator v1.1.0: bulk TSV 선택적 TITLE 컬럼(5컬럼) 지원 추가 — YouTube 채널처럼 metadata가 빈약한 URL 제출 시 HoneyCombo 서버가 title과 description을 동일하게 fallback하는 문제 예방. `submit_bulk.sh` 배열 기반 파싱으로 4컬럼(legacy)·5컬럼(v2) 자동 감지, TITLE/SUMMARY 필드에 `|`, 탭, CR/LF 문자 금지(서버 컬럼 정렬 보호), Unix 라인엔딩 일관성을 위한 `.gitattributes` 추가(`*.sh text eol=lf`). `honeycombo-submission.md`와 `SKILL.md`에 v2 포맷 사용법·금지 문자 문서화. (연결 서버 PR: orientpine/honeycombo#169 — `deriveShortTitle`/`resolveSubmissionTitle` fallback chain + 5컬럼 파서 + bulk 실패 URL 상세 댓글 upsert) |
 | 3.28.1 | 2026-04-21 | 4개 플러그인(wiki-gen, pptx-design-styles, patent-trend-analyzer, obsidian-skills)과 root marketplace.json의 **plugin.json/marketplace.json 스키마 준수 수정** — Claude Code Zod strict validation이 `Unrecognized keys` 에러로 거부하던 비표준 `contributors` 필드 전량 제거로 마켓플레이스 등록 실패 해결. AGENTS.md에 `Plugin.json Schema Compliance (CRITICAL)` 섹션 신설(공식 허용 필드 화이트리스트, 금지 필드 목록, Attribution 보존 4가지 방안, 검증 Python 스크립트, 실패 에러 패턴/조치 절차). patent-trend-analyzer README에 Gunju Park contributor attribution 이동. 개별 플러그인 PATCH 버전 업(wiki-gen 1.2.0→1.2.1, pptx-design-styles 1.0.0→1.0.1, patent-trend-analyzer 1.3.0→1.3.1, obsidian-skills 1.0.0→1.0.1). |
 | 3.27.0 | 2026-04-10 | wiki-gen v1.2.0: wiki sync 서브커맨드 추가 — sources.yaml 기반 멀티소스 수집 파이프라인 (sync_sources.py, ingest_projects.py, ingest_common.py), pytest 인프라 + 27개 자동화 테스트 |
 | 3.28.0 | 2026-04-20 | link-curator 플러그인 추가 — URL fetch → Korean MD summary notes 생성 (link-summarizer) + gh CLI HoneyCombo submission (honeycombo-submit), single/bulk 제출, `--dry-run` 지원 |

--- a/plugins/link-curator/.claude-plugin/plugin.json
+++ b/plugins/link-curator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "link-curator",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "URL → Korean markdown summary notes (link-summarizer) + HoneyCombo submission (honeycombo-submit) via gh CLI",
   "author": {
     "name": "Baekdong Cha",

--- a/plugins/link-curator/.gitattributes
+++ b/plugins/link-curator/.gitattributes
@@ -1,0 +1,10 @@
+# Bash scripts must use LF line endings regardless of host OS.
+# A CRLF-checked-out `submit_bulk.sh` / `submit_single.sh` fails on
+# Unix with `bash\r: not found` or silently mis-parses shebang arguments.
+*.sh text eol=lf
+
+# Markdown and JSON configs: keep LF too for cross-platform stability.
+*.md text eol=lf
+*.json text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf

--- a/plugins/link-curator/skills/honeycombo-submit/SKILL.md
+++ b/plugins/link-curator/skills/honeycombo-submit/SKILL.md
@@ -25,6 +25,7 @@ Trigger phrases: "허니콤보에 올려줘", "submit to honeycombo", "제출해
 For each submittable URL, derive:
 
 - **Type**: `Article` (default) | `YouTube` | `X Thread` | `Threads` | `Other`. See [references/honeycombo-submission.md](references/honeycombo-submission.md) for URL-pattern mapping.
+- **Title** (optional but RECOMMENDED for bulk): short Korean/English title (<=200 chars, no `|`, tab, CR, or LF). For URLs with weak metadata (e.g., YouTube channel pages), providing an explicit title prevents the server from falling back to using the summary as both title and description. Skip for single submit — single-submit body does not carry a title field.
 - **Tags**: 1-5 English tags, comma+space separated. Extract from md content. No Korean.
 - **Summary**: Korean structured summary (≤5000 chars for single, ≤500 chars for bulk) with `## 개요`, `## 주요 내용`, `## 시사점` sections.
 
@@ -32,6 +33,9 @@ For each submittable URL, derive:
 
 - **1-5 URLs → single submit, ONE Issue per URL.** Write summary to a temp file, then call `scripts/submit_single.sh`.
 - **6-20 URLs → one bulk Issue.** Write a TSV with single-line Korean summaries, then call `scripts/submit_bulk.sh`.
+  - TSV 포맷: 4컬럼 `URL<TAB>TYPE<TAB>TAGS<TAB>SUMMARY` (legacy) 또는 5컬럼 `URL<TAB>TYPE<TAB>TITLE<TAB>TAGS<TAB>SUMMARY` (권장). 각 줄마다 자율 선택—스크립트가 탭 개수로 자동 감지한다.
+  - YouTube 채널·약한 metadata URL의 title≐description 중복을 방지하려면 5컬럼 사용 필수.
+  - TITLE/SUMMARY 필드에 `|`, 탭, CR/LF 문자 금지 (서버 파서가 행을 드롭).
 - **>20 URLs → split into ≤20-entry bulk Issues** (`📦 Bulk Submit (1/N)`, `(2/N)`, ...).
 - Add `--dry-run` flag to preview commands without executing.
 

--- a/plugins/link-curator/skills/honeycombo-submit/references/honeycombo-submission.md
+++ b/plugins/link-curator/skills/honeycombo-submit/references/honeycombo-submission.md
@@ -151,28 +151,44 @@ bash scripts/submit_single.sh \
 
 단일 Issue에 `### Link List` **하나만** 사용 (단건의 4개 헤더와 다름).
 
-각 줄 포맷: `URL | Type | Tags | 한국어 요약`
+각 줄은 다음 두 포맷 중 하나로 작성한다 (서버는 `|` 개수로 자동 감지):
+
+### v1 (legacy, 4컬럼)
+
+`URL | Type | Tags | 한국어 요약`
+
+### v2 (제목 포함, 5컬럼) — 권장
+
+`URL | Type | 제목 | Tags | 한국어 요약`
+
+YouTube 채널처럼 metadata가 빈약한 URL에서 HoneyCombo 서버가 title을 description과 동일하게 fallback하는 문제를 방지하기 위해 **가능하면 5컬럼을 사용하라**. 제목은 한국어/영어 모두 허용, `<=` 200자.
+
+### 공통 규칙
+
 - 구분자: ` | ` (공백+파이프+공백)
 - 쉼표는 Tags 내부에서만 (파이프 구분자와 충돌 주의)
-- 한국어 요약에 ` | ` 포함 금지
+- 제목·요약에 **`|`, 탭, CR/LF 포함 금지** (서버 파서가 컬럼 정렬 실패)
 - 한국어 요약은 **단일 행**, ≤500자
 
 ```bash
 gh issue create --repo orientpine/honeycombo --title "📦 Bulk Submit" --body "### Link List
 
 https://blog.com/post-1 | Article | AI, LLM | AI 에이전트를 프로덕션 환경에서 활용하는 실전 분석 기사
-https://blog.com/post-2 | Article | MCP, agents | MCP 서버를 활용한 AI 에이전트 구축 가이드
-https://youtube.com/watch?v=abc | YouTube | AI, tutorial | Claude Code 개발 환경 설정 튜토리얼 영상
+https://blog.com/post-2 | Article | MCP 서버 구축 가이드 | MCP, agents | MCP 서버를 활용한 AI 에이전트 구축 가이드
+https://youtube.com/watch?v=abc | YouTube | Claude Code 튜토리얼 | AI, tutorial | Claude Code 개발 환경 설정 튜토리얼 영상
 "
 ```
 
-래퍼 스크립트:
+### 래퍼 스크립트
 
 ```bash
 bash scripts/submit_bulk.sh /tmp/links.tsv
 ```
 
-`/tmp/links.tsv`는 탭 구분 `URL<TAB>Type<TAB>Tags<TAB>한국어 요약` 포맷.
+TSV 포맷은 줄 단위로 4컬럼 또는 5컬럼을 혼용할 수 있으며 스크립트가 탭 개수로 자동 감지한다.
+
+- 4컬럼: `URL<TAB>Type<TAB>Tags<TAB>한국어 요약`
+- 5컬럼 (권장): `URL<TAB>Type<TAB>제목<TAB>Tags<TAB>한국어 요약`
 
 ---
 
@@ -232,7 +248,7 @@ gh run list --repo orientpine/honeycombo --limit 5
 
 ### 중복 URL
 
-HoneyCombo가 자동 거부. 사전에 기존 글 검색 불가능하므로 그냥 제출하고 결과 확인.
+HoneyCombo가 자동 거부하고 Issue에 상세 댓글을 남긴다 (동일 Issue 재처리 시에도 댓글이 upsert되므로 중복 생성 없음). 사전에 기존 글 검색 불가능하므로 그냥 제출하고 결과 Issue 댓글을 확인한다.
 
 ---
 

--- a/plugins/link-curator/skills/honeycombo-submit/scripts/submit_bulk.sh
+++ b/plugins/link-curator/skills/honeycombo-submit/scripts/submit_bulk.sh
@@ -3,14 +3,26 @@
 #
 # Usage: submit_bulk.sh [--dry-run] <TSV_FILE> [TITLE_SUFFIX]
 #   --dry-run    Print the gh command without executing
-#   TSV_FILE     Tab-separated file, one entry per line:
-#                  URL<TAB>TYPE<TAB>TAGS<TAB>SUMMARY
+#   TSV_FILE     Tab-separated file, one entry per line.
+#
+# Two column formats are accepted (auto-detected per line by TAB count):
+#
+#   v1 (legacy, 4 columns):
+#     URL<TAB>TYPE<TAB>TAGS<TAB>SUMMARY
+#
+#   v2 (with explicit title, 5 columns) -- preferred for weak-metadata URLs:
+#     URL<TAB>TYPE<TAB>TITLE<TAB>TAGS<TAB>SUMMARY
 #
 #     TYPE    - Article | YouTube | X Thread | Threads | Other
+#     TITLE   - OPTIONAL short Korean/English title (<= 200 chars, must not
+#               contain '|', tab, CR, or LF). Present only in 5-column rows.
 #     TAGS    - Comma+space separated, 1-5 English tags
-#     SUMMARY - Korean single-line summary, ≤500 chars. Must not contain ' | '
+#     SUMMARY - Korean single-line summary, <= 500 chars. Must not contain
+#               '|', tab, CR, or LF (these would collide with the Issue body
+#               delimiter that HoneyCombo's server-side parser splits on).
 #
-# The '### Link List' header is parsed LITERALLY by HoneyCombo automation. Do not edit.
+# The '### Link List' header and the ' | ' (space-pipe-space) row delimiter
+# are parsed LITERALLY by HoneyCombo automation. Do not edit.
 
 set -euo pipefail
 
@@ -44,7 +56,7 @@ if ! gh auth status >/dev/null 2>&1; then
   exit 4
 fi
 
-# Normalize line endings
+# Normalize line endings (CRLF -> LF) and ensure trailing newline.
 NORMALIZED=$(mktemp)
 trap 'rm -f "$NORMALIZED"' EXIT
 sed -e 's/\r$//' "$TSV_FILE" > "$NORMALIZED"
@@ -61,15 +73,58 @@ if [ "$LINE_COUNT" -gt 20 ]; then
   exit 2
 fi
 
+# Reject any pipe/tab/CR/LF in a field. The server parser splits the body
+# on '|' so any literal pipe inside a TITLE/SUMMARY field would break column
+# alignment, and tab/CR/LF would break the single-line row layout.
+has_forbidden_char() {
+  local value="$1"
+  if [[ "$value" == *'|'* ]] || [[ "$value" == *$'\t'* ]] \
+     || [[ "$value" == *$'\r'* ]] || [[ "$value" == *$'\n'* ]]; then
+    return 0
+  fi
+  return 1
+}
+
 BODY_LINES=""
 VALID_COUNT=0
 LINE_NO=0
-while IFS=$'\t' read -r URL TYPE TAGS SUMMARY; do
-  LINE_NO=$((LINE_NO + 1))
-  [ -z "${URL:-}${TYPE:-}${TAGS:-}${SUMMARY:-}" ] && continue
 
+# IMPORTANT: Read the raw line first and split into an array so we can
+# distinguish 4-column from 5-column rows. Using `read -r URL TYPE TAGS SUMMARY`
+# directly would silently fold a 5th column into SUMMARY.
+while IFS= read -r raw_line || [ -n "$raw_line" ]; do
+  LINE_NO=$((LINE_NO + 1))
+
+  # Skip blank lines.
+  [[ -z "${raw_line//[[:space:]]/}" ]] && continue
+
+  IFS=$'\t' read -r -a COLS <<< "$raw_line"
+  NUM_COLS=${#COLS[@]}
+
+  case "$NUM_COLS" in
+    4)
+      URL="${COLS[0]}"
+      TYPE="${COLS[1]}"
+      TITLE=""
+      TAGS="${COLS[2]}"
+      SUMMARY="${COLS[3]}"
+      ;;
+    5)
+      URL="${COLS[0]}"
+      TYPE="${COLS[1]}"
+      TITLE="${COLS[2]}"
+      TAGS="${COLS[3]}"
+      SUMMARY="${COLS[4]}"
+      ;;
+    *)
+      echo "ERROR: Line $LINE_NO has $NUM_COLS tab-separated fields; expected 4 (URL|TYPE|TAGS|SUMMARY) or 5 (URL|TYPE|TITLE|TAGS|SUMMARY)." >&2
+      exit 2
+      ;;
+  esac
+
+  # Required fields
   if [ -z "${URL:-}" ] || [ -z "${TYPE:-}" ] || [ -z "${TAGS:-}" ] || [ -z "${SUMMARY:-}" ]; then
-    echo "ERROR: Line $LINE_NO has empty field. Require all 4 TSV columns." >&2
+    echo "ERROR: Line $LINE_NO has empty required field (URL/TYPE/TAGS/SUMMARY)." >&2
     exit 2
   fi
 
@@ -88,6 +143,19 @@ while IFS=$'\t' read -r URL TYPE TAGS SUMMARY; do
       ;;
   esac
 
+  # Validate optional TITLE (5-column rows only)
+  if [ -n "$TITLE" ]; then
+    if has_forbidden_char "$TITLE"; then
+      echo "ERROR: Line $LINE_NO title contains forbidden character (|, tab, CR, or LF) for URL '$URL'" >&2
+      echo "       Server parser splits Issue body on ' | '; pipes inside fields break column alignment." >&2
+      exit 2
+    fi
+    if [ "${#TITLE}" -gt 200 ]; then
+      echo "ERROR: Line $LINE_NO title exceeds 200 chars for URL '$URL'" >&2
+      exit 2
+    fi
+  fi
+
   # Validate TAGS (1-5 comma-separated)
   tag_count=$(awk -F',' '{print NF}' <<<"$TAGS")
   if [ "$tag_count" -lt 1 ] || [ "$tag_count" -gt 5 ]; then
@@ -101,7 +169,7 @@ while IFS=$'\t' read -r URL TYPE TAGS SUMMARY; do
     exit 2
   fi
 
-  # Validate individual tags are non-empty (reject leading/trailing commas, consecutive commas)
+  # Validate individual tags are non-empty
   if [[ "$TAGS" =~ ^, ]] || [[ "$TAGS" =~ ,$ ]] || [[ "$TAGS" =~ ,, ]]; then
     echo "ERROR: Line $LINE_NO tags contain empty entries (leading/trailing/consecutive commas) (URL: $URL)" >&2
     exit 2
@@ -115,14 +183,15 @@ while IFS=$'\t' read -r URL TYPE TAGS SUMMARY; do
     fi
   done
 
-  # Validate SUMMARY (Korean single-line, ≤500 chars, no ' | ')
+  # Validate SUMMARY (Korean single-line, <=500 chars, no pipe/tab/CR/LF)
   if [ "${#SUMMARY}" -gt 500 ]; then
     echo "ERROR: Line $LINE_NO summary exceeds 500 chars (URL: $URL)" >&2
     exit 2
   fi
 
-  if [[ "$SUMMARY" == *" | "* ]]; then
-    echo "ERROR: Line $LINE_NO summary contains ' | ' which collides with bulk delimiter (URL: $URL)" >&2
+  if has_forbidden_char "$SUMMARY"; then
+    echo "ERROR: Line $LINE_NO summary contains forbidden character (|, tab, CR, or LF) for URL '$URL'" >&2
+    echo "       Server parser splits Issue body on ' | '; pipes inside fields break column alignment." >&2
     exit 2
   fi
 
@@ -132,7 +201,13 @@ while IFS=$'\t' read -r URL TYPE TAGS SUMMARY; do
     exit 2
   fi
 
-  LINE="$URL | $TYPE | $TAGS | $SUMMARY"
+  # Emit the Issue body row in the matching format (4 or 5 pipe-separated fields).
+  if [ -n "$TITLE" ]; then
+    LINE="$URL | $TYPE | $TITLE | $TAGS | $SUMMARY"
+  else
+    LINE="$URL | $TYPE | $TAGS | $SUMMARY"
+  fi
+
   if [ -z "$BODY_LINES" ]; then
     BODY_LINES="$LINE"
   else
@@ -151,16 +226,16 @@ BODY="### Link List
 $BODY_LINES
 "
 
-TITLE="📦 Bulk Submit"
+TITLE_FIELD="📦 Bulk Submit"
 if [ -n "$TITLE_SUFFIX" ]; then
-  TITLE="$TITLE $TITLE_SUFFIX"
+  TITLE_FIELD="$TITLE_FIELD $TITLE_SUFFIX"
 fi
 
 if [ "$DRY_RUN" = true ]; then
   echo "=== DRY RUN ==="
   echo "gh issue create \\"
   echo "  --repo orientpine/honeycombo \\"
-  echo "  --title \"$TITLE\" \\"
+  echo "  --title \"$TITLE_FIELD\" \\"
   echo "  --body \"<body: ${#BODY} chars, $VALID_COUNT entries>\""
   echo ""
   echo "--- Body Preview ---"
@@ -170,5 +245,5 @@ fi
 
 gh issue create \
   --repo orientpine/honeycombo \
-  --title "$TITLE" \
+  --title "$TITLE_FIELD" \
   --body "$BODY"


### PR DESCRIPTION
﻿## Summary

Client-side companion to orientpine/honeycombo#169. Adds an **optional TITLE column** to the bulk TSV format so submitters can pre-specify a short title for URLs whose metadata is too weak for the server's title auto-derivation (e.g. YouTube channel pages).

Without a pre-specified title, the HoneyCombo server's `extractTitleFromNote` fallback copies the summary into the `title` field, producing `title == description` overlap (concrete case: Issue #155 where 7/8 merged articles had title=description of 120~240 chars each).

## Changes

### `submit_bulk.sh` \u2014 full rewrite of the parse loop

**Old**: `while IFS=$'\t' read -r URL TYPE TAGS SUMMARY` silently folded any 5th column into SUMMARY.

**New**: Read each raw line into an array, auto-detect 4-column (legacy) vs 5-column (v2) rows by tab count:

`
v1 legacy:  URL<TAB>TYPE<TAB>TAGS<TAB>SUMMARY
v2 new:     URL<TAB>TYPE<TAB>TITLE<TAB>TAGS<TAB>SUMMARY
`

The emitted Issue body row matches the input column count, so no server-side ambiguity.

### Forbidden character validation

TITLE and SUMMARY fields now reject `|`, tab, CR, and LF. The server parser splits the Issue body on ` | ` so any pipe inside a field breaks column alignment (Oracle flagged this as a hidden failure mode). Tab/CR/LF would also break the single-line row layout.

TITLE has a 200-char cap.

### `.gitattributes`

New file enforcing LF line endings on `*.sh`, `*.md`, `*.json`, `*.yml`, `*.yaml`. Prevents Windows checkouts from producing CRLF-corrupted bash scripts that fail on Linux CI with `bash\r: not found`.

### Documentation

- `references/honeycombo-submission.md` \u2014 documented v1/v2 formats, `|`/tab/CR/LF forbidden, duplicate-URL behavior updated to reflect new upsert comment on the server.
- `SKILL.md` \u2014 added optional TITLE field to the metadata derivation step, updated TSV format in submit step with v1/v2 note and YouTube-channel caveat.

### Version bumps (MANDATORY per AGENTS.md versioning policy)

| File | Before | After |
|---|---|---|
| `plugins/link-curator/.claude-plugin/plugin.json` | 1.0.0 | 1.1.0 |
| `.claude-plugin/marketplace.json` link-curator entry | 1.0.0 | 1.1.0 |
| `.claude-plugin/marketplace.json` metadata.version | 3.28.1 | 3.29.0 |
| `AGENTS.md` Version | 3.28.1 | 3.29.0 |
| `README.md` Version + changelog | 3.28.1 | 3.29.0 (new row) |

## Validation

- `python` JSON syntax check on all `plugins/*/.claude-plugin/plugin.json` + `marketplace.json`: **OK**
- plugin.json whitelist check (Zod strict-validation compatibility): **clean** for all 18 plugins, including link-curator.
- marketplace.json link-curator entry whitelist: **clean**.
- `submit_bulk.sh --dry-run` with mixed 4-col + 5-col TSV:
  - Correctly auto-detects per-row format
  - Emits matching Issue body row for each line
- `submit_bulk.sh --dry-run` with `Bad|Title` in TITLE column:
  - Rejects with exit code 2 and the message `ERROR: Line 1 title contains forbidden character...`

## Backward compatibility

- 4-column legacy TSV submissions work unchanged; client and server both still accept them.
- TITLE is **optional** \u2014 omit it (4-column row) and the server applies its existing oEmbed/derive fallback chain.
- Script behavior for 4-column input is identical to v1.0.0 except that SUMMARY now also rejects bare pipes (previously only `' | '`). This is a **stricter** check designed to match server parser behavior; if a caller was relying on `|` inside summary text, they must now escape or rephrase.

## Related

- Server PR: orientpine/honeycombo#169 (`deriveShortTitle` + `resolveSubmissionTitle` + 5-column parser + bulk-result.json failure reporting)
- Trigger incident: orientpine/honeycombo#155 (partial merge 8/9, silent duplicate drop, title=description on 7 articles)
